### PR TITLE
Make Package installable & runnable (deps, dev tools)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,12 @@ dependencies = [ # Optional
   "h5py",
   "numpy",
   "scipy",
-  "scikit-image",
+  "scikit-image<0.25",   # <- temp pinning (skeletonize_3d disabled for newer versions)
   "tifffile",
   "toml",
   "zarr",
+  "natsort",
+  "matplotlib" 
 ]
 
 # List additional groups of dependencies here (e.g. development
@@ -125,6 +127,7 @@ dependencies = [ # Optional
 # Similar to `dependencies` above, these must be valid existing
 # projects.
 [project.optional-dependencies] # Optional
+dev = ["pytest", "black", "ruff", "pre-commit"]
 # dev = ["check-manifest"]
 # test = ["coverage"]
 


### PR DESCRIPTION
## What
- Add runtime deps: natsort, matplotlib
- Temp pin: scikit-image<0.25 (skeletonize_3d was removed in >=0.25)
- Add dev extras: [project.optional-dependencies].dev

## Why
Enabling a clean installation + CLI + tests for reviewers/devs.

## How tested
```bash
pip install -e ".[dev]"
evalinstseg --help
python -m pytest -q   # currently: 2 passed, 1 failing case (see below)
```

## Next
- Replace skeletonize_3d → skeletonize(method="lee") & remove pin
- Fix non-overlapping 3D matching
- Add pre-commit & CI