### PR TITLE
Fixed gm2m and sub modules

### DIFF
--- a/evalinstseg/compute.py
+++ b/evalinstseg/compute.py
@@ -51,7 +51,7 @@ def get_gt_coverage(gt_labels, pred_labels, precMat, recallMat):
 
 # TODO: check consistent use gt_labels_rel and gt_labels!!!
 def get_gt_coverage_dim(dim_insts, gt_labels_rel, pred_labels_rel,
-        num_pred_labels, locMat, recallMat):
+        num_pred_labels, locMat, recallMat, assignment_strategy="greedy"):
     tp_05_dim = 0
     tp_05_rel_dim = 0.0
     gt_covs_dim = []
@@ -89,7 +89,7 @@ def get_gt_coverage_dim(dim_insts, gt_labels_rel, pred_labels_rel,
 
 # TODO: merge with get_gt_coverage_dim to get_gt_coverage_subset
 def get_gt_coverage_overlap(ovlp_inst_ids, gt_labels_rel, pred_labels_rel,
-        num_pred_labels, locMat, recallMat):
+        num_pred_labels, locMat, recallMat, assignment_strategy="greedy"):
     tp_05_ovlp = 0
     tp_05_rel_ovlp = 0.0
     gt_covs_ovlp = []
@@ -125,7 +125,8 @@ def get_gt_coverage_overlap(ovlp_inst_ids, gt_labels_rel, pred_labels_rel,
             tp_05_ovlp, _, _ = assign_labels(
                 locMat_subset, assignment_strategy, 0.5, 1)
         tp_05_rel_ovlp = tp_05_ovlp / float(gt_ovlp)
-    return gt_dim, tp_05_dim, tp_05_rel_dim, gt_covs_dim, avg_cov_dim
+    return gt_ovlp, tp_05_ovlp, tp_05_rel_ovlp, gt_covs_ovlp, avg_cov_ovlp
+
 
 
 def get_m2m_fm(gt_labels, pred_labels, num_pred_labels,

--- a/evalinstseg/evaluate.py
+++ b/evalinstseg/evaluate.py
@@ -371,14 +371,14 @@ def evaluate_volume(
         # TODO: rename "false_merge" and "false_splits" to sth with many-to-many?
         m2m_matches = None
         if "false_merge" in add_general_metrics:
-            fm, m2m_matches = get_m2m_fm(gt_labels, pred_labels, num_pred_labels,
+            fm, m2m_matches = get_m2m_fm(gt_labels_rel, pred_labels_rel, num_pred_labels,
                     recallMat, fm_thresh)
             metrics.addMetric("general", "FM", fm)
         if "false_split" in add_general_metrics:
             # if fm and fs thresh are different, reset matches, reuse otherwise
             if fm_thresh != fs_thresh:
                 m2m_matches = None
-            fs, _ = get_m2m_fs(gt_labels, pred_labels, recallMat,
+            fs, _ = get_m2m_fs(gt_labels_rel, pred_labels_rel, recallMat,
                     fs_thresh, m2m_matches)
             metrics.addMetric("general", "FS", fs)
 

--- a/evalinstseg/evaluate.py
+++ b/evalinstseg/evaluate.py
@@ -208,7 +208,7 @@ def evaluate_volume(
     if partly:
         evaluate_false_labels = True
 
-    # check sizes and crop if necessary
+    # check sizes and crop if necessary, unify input into per instance arrays
     gt_labels, pred_labels = check_and_fix_sizes(gt_labels, pred_labels, ndim)
     if len(dim_insts) > 0:
         gt_labels_rel, pred_labels_rel, dim_insts_rel = check_fix_and_unify_ids(
@@ -385,7 +385,7 @@ def evaluate_volume(
         if "avg_gt_cov_dim" in add_general_metrics:
             gt_dim, tp_05_dim, tp_05_rel_dim, gt_covs_dim, avg_cov_dim = \
                     get_gt_coverage_dim(dim_insts_rel, gt_labels_rel, pred_labels_rel,
-                            num_pred_labels, locMat, recallMat)
+                            num_pred_labels, locMat, recallMat, assignment_strategy)
             # add to metrics
             metrics.addMetric("general", "GT_dim", gt_dim)
             metrics.addMetric("general", "TP_05_dim", tp_05_dim)
@@ -398,9 +398,9 @@ def evaluate_volume(
             ovlp_inst_ids = np.unique(gt_labels_rel[:, overlap_mask])
 
             gt_ovlp, tp_05_ovlp, tp_05_rel_ovlp, gt_covs_ovlp, avg_cov_ovlp = \
-                    get_gt_coverage_overlap(dim_insts, gt_labels_rel, pred_labels_rel,
-                            num_pred_labels, locMat, recallMat)
-            # add to metrics
+                    get_gt_coverage_overlap(ovlp_inst_ids, gt_labels_rel, pred_labels_rel,
+                            num_pred_labels, locMat, recallMat, assignment_strategy)
+            # add to metricss
             metrics.addMetric("general", "GT_overlap", gt_ovlp)
             metrics.addMetric("general", "TP_05_overlap", tp_05_ovlp)
             metrics.addMetric("general", "TP_05_rel_overlap", tp_05_rel_ovlp)

--- a/evalinstseg/util.py
+++ b/evalinstseg/util.py
@@ -100,11 +100,37 @@ def remove_empty_channels(labels):
 
     return np.array(tmp_labels)
 
+def expand_single_channel_to_stack(labels):
+    """
+    Expand a single-channel instance mask into a stack of binary masks.
+
+    Parameters
+    ----------
+    labels : np.ndarray
+        Array of shape (1, Z, Y, X) with integer instance IDs.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (N, Z, Y, X), one binary mask per instance.
+    """
+    # Remove unnecessary channel dimension
+    vol = labels[0]
+
+    # Determine number of unique instances
+    max_id = np.max(vol)
+    if max_id <= 1:
+        return labels
+    
+    # Create binary masks for each instance
+    masks = [(vol == k) for k in range(1, max_id + 1)]
+    return np.stack(masks, axis=0).astype(labels.dtype)
+
 
 def check_fix_and_unify_ids(
         gt_labels, pred_labels, remove_small_components, foreground_only,
         dim_insts=[]):
-    """unify prediction and gt labelling styles
+    """unify prediction and gt labelling styles #! Wouldnt it make sense to also unify the representation of the UIDs (f.e, only channel per instamce instead of either single channel or channel per instance)
 
     Note
     ----
@@ -136,6 +162,16 @@ def check_fix_and_unify_ids(
             pred_labels[gt_labels==0] = 0
         else:
             pred_labels[:, np.all(gt_labels, axis=0).astype(int)==0] = 0
+
+    if (gt_labels.shape[0] == 1 
+        and np.max(gt_labels) > 1 
+        and np.issubdtype(gt_labels.dtype, np.integer)):
+        gt_labels = expand_single_channel_to_stack(gt_labels)
+
+    if (pred_labels.shape[0] == 1 
+        and np.max(pred_labels) > 1 
+        and np.issubdtype(pred_labels.dtype, np.integer)):
+        pred_labels = expand_single_channel_to_stack(pred_labels)
 
     # after filtering, some channels might be empty
     pred_labels = remove_empty_channels(pred_labels)

--- a/evalinstseg/util.py
+++ b/evalinstseg/util.py
@@ -12,7 +12,7 @@ import zarr
 logger = logging.getLogger(__name__)
 
 
-def crop(arr, shape):
+def crop(arr, target_shape):
     """center-crop arr to shape
 
     Args
@@ -26,13 +26,13 @@ def crop(arr, shape):
     -------
     cropped array
     """
-
-    target_shape = arr.shape()[:-len(shape)] + shape
+    target_shape = tuple(target_shape)
 
     offset = tuple(
-        (a - b)//2
-        for a, b in zip(arr.shape(), target_shape))
-
+        (a - b) // 2
+        for a, b in zip(arr.shape[-len(target_shape):], target_shape)
+    )
+    
     slices = tuple(
         slice(o, o + s)
         for o, s in zip(offset, target_shape))
@@ -163,6 +163,7 @@ def check_fix_and_unify_ids(
         else:
             pred_labels[:, np.all(gt_labels, axis=0).astype(int)==0] = 0
 
+    # Build binary masks if single-channel but multiple instances
     if (gt_labels.shape[0] == 1 
         and np.max(gt_labels) > 1 
         and np.issubdtype(gt_labels.dtype, np.integer)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,12 @@ dependencies = [ # Optional
   "h5py",
   "numpy",
   "scipy",
-  "scikit-image",
+  "scikit-image<0.25",   # <- temp pinning (skeletonize_3d disabled for newer versions)
   "tifffile",
   "toml",
   "zarr",
+  "natsort",
+  "matplotlib" 
 ]
 
 # List additional groups of dependencies here (e.g. development
@@ -125,6 +127,7 @@ dependencies = [ # Optional
 # Similar to `dependencies` above, these must be valid existing
 # projects.
 [project.optional-dependencies] # Optional
+dev = ["pytest", "black", "ruff", "pre-commit"]
 # dev = ["check-manifest"]
 # test = ["coverage"]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -80,7 +80,6 @@ class TestMetrics(unittest.TestCase):
             config["visualize_type"],
             config["overlapping_inst"],
             config["partly"])
-        print(result_dict)
         self.check_results(result_dict.metricsDict, expected)
 
     def test_2d_nuclei(self):


### PR DESCRIPTION
## Summary
- Corrected misnamed variables and return values in:
  -  match.greedy_many_to_many_matching
  - compute.get_gt_coverage_dim
   - compute.get_gt_coverage_overlap
- In evaluate.evaluate_volume:
  - Pass assignment_strategy into DIM/overlap helpers
  - Call the correct helpers with the correct arguments (f.e, ovlp_inst_ids)

## How tested
-  run FlyLight crop (3D, clDice) locally (no overlaps present)


> python -m evalinstseg.evaluate `
>   --res_file tests\pred_crop `
>   --gt_file  tests\gt_crop `
>   --res_key  volumes/gmm_label_cleaned `
>   --gt_key   volumes/gt_instances `
>   --out_dir  results\flylight_crop `
>   --ndim 3 `
>   --localization_criterion cldice `
>   --assignment_strategy greedy `
>   --add_general_metrics avg_gt_skel_coverage avg_f1_cov_score false_merge false_split avg_gt_cov_overlap `
>   --evaluate_false_labels `
>   --from_scratch

Overlap metrics return GT_overlap = 0, TP_05_overlap = 0, avg_gt_cov_overlap = 0, gt_covs_overlap = [] -- as expected.
